### PR TITLE
Fix code scanning alert no. 1: Incomplete regular expression for hostnames

### DIFF
--- a/helpers/directory.ts
+++ b/helpers/directory.ts
@@ -310,7 +310,7 @@ export async function calculateStatistics(devpoolIssues: GitHubIssue[]) {
     if ("repo" in issue && issue.repo != DEVPOOL_REPO_NAME) return;
 
     const linkedRepoFromBody = issue.body?.match(/https:\/\/github.com\/[^/]+\/[^/]+/);
-    const linkedRepoFromBodyForked = issue.body?.match(/https:\/\/www.github.com\/[^/]+\/[^/]+/);
+    const linkedRepoFromBodyForked = issue.body?.match(/https:\/\/www\.github\.com\/[^/]+\/[^/]+/);
 
     let shouldExclude = optInOptOut.out.some((orgOrRepo) => linkedRepoFromBody?.[0].includes(orgOrRepo));
     shouldExclude = shouldExclude || optInOptOut.out.some((orgOrRepo) => linkedRepoFromBodyForked?.[0].includes(orgOrRepo));


### PR DESCRIPTION
Fixes [https://github.com/Apetree100122/devpool-directory/security/code-scanning/1](https://github.com/Apetree100122/devpool-directory/security/code-scanning/1)

To fix the problem, we need to escape the `.` character in the regular expression to ensure it matches a literal dot rather than any character. This can be done by replacing `.` with `\.` in the regular expression. Specifically, we need to change the regular expression from `https:\/\/www.github.com\/[^/]+\/[^/]+` to `https:\/\/www\.github\.com\/[^/]+\/[^/]+`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
